### PR TITLE
2019春関東戦績追加(0709)

### DIFF
--- a/result.html
+++ b/result.html
@@ -31,6 +31,17 @@
         <p class="head">女子部</p>
       </div>
     </div>
+    <h3 class="head">2019</h3>
+    <div class="main">
+        <div class="big_menu">
+            <div class="content">
+              <a href="result/2019/men/kanto_spring.html">
+              <p>関東学生ソフトテニス春季リーグ</p>
+              <p class="record">8部 3勝2敗 2位</p>
+              </a>
+            </div>
+        </div>
+    </div>
     <h3 class="head">2018</h3>
     <div class="main">
       <div class="big_menu">

--- a/result/2019/men/kanto_spring.html
+++ b/result/2019/men/kanto_spring.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Result | 東工大ソフトテニス部</title>
+  <link rel="stylesheet" href="../../../common.css">
+  <link rel="stylesheet" href="../../../css/result.css">
+</head>
+<body class="sample">
+  <div id="result" class="page">
+    <header>
+      <h1 class="siteTitle">東工大ソフトテニス部</h1>
+      <nav class="globalNavi">
+        <ul class="menu">
+          <li><a href="../../../index.html">home</a></li>
+          <li><a href="../../../schedule.html">schedule</a></li>
+          <li class="current"><a href="../../../result.html">result</a></li>
+          <li><a href="../../../album.html">album</a></li>
+          <li><a href="../../../data.html">data</a></li>
+        </ul>
+      </nav>
+    </header>
+    <h3 class="head">2019年度関東学生ソフトテニス春季リーグ戦</h3>
+    <table class="type01">
+      <tr>
+        <th>8部</th>
+        <th>1</th>
+        <th>2</th>
+        <th>3</th>
+        <th>4</th>
+        <th>5</th>
+        <th>6</th>
+        <th>勝数</th>
+        <th>順位</th>
+      </tr>
+      <tr>
+        <th>1,獨協大学</th>
+        <td></td>
+        <td>1</td>
+        <td>2</td>
+        <td>③</td>
+        <td>1</td>
+        <td>2</td>
+        <td>1</td>
+        <td>6</td>
+      </tr>
+      <tr>
+        <th>2,一橋大学</th>
+        <td>④</td>
+        <td></td>
+        <td>③</td>
+        <td>③</td>
+        <td>2</td>
+        <td>③</td>
+        <td>4</td>
+        <td>1</td>
+      </tr>
+      <tr>
+        <th>3,淑徳大学</th>
+        <td>③</td>
+        <td>2</td>
+        <td></td>
+        <td>2</td>
+        <td>③</td>
+        <td>1</td>
+        <td>2</td>
+        <td>5</td>
+      </tr>
+      <tr>
+        <th>4,東京工業大学</th>
+        <td>2</td>
+        <td>2</td>
+        <td>③</td>
+        <td></td>
+        <td>③</td>
+        <td>③</td>
+        <td>3</td>
+        <td>2</td>
+      </tr>
+      <tr>
+        <th>5,東京都市大学</th>
+        <td>④</td>
+        <td>③</td>
+        <td>2</td>
+        <td>2</td>
+        <td></td>
+        <td>2</td>
+        <td>2</td>
+        <td>4</td>
+      </tr>
+      <tr>
+        <th>6,宇都宮大学</th>
+        <td>③</td>
+        <td>2</td>
+        <td>④</td>
+        <td>2</td>
+        <td>③</td>
+        <td></td>
+        <td>3</td>
+        <td>3</td>
+      </tr>
+    </table>
+    <div class="main">
+      <div class="record2">
+        <h4>第一回戦 vs 淑徳大学</h4>
+        <p>1.小八木 高橋(慧) 2-⑤ 吉田 田中</p>
+        <p>2.髙橋(一) 瀧谷 2-⑤ 森本 中村</p>
+        <p>3.田淵 ④-3 鹿嶋</p>
+        <p>4.田村 久保田 ⑤-R open</p>
+        <p>5.難波 三田 ⑤-R open
+        </p>
+        <p>以上③-2勝ち</p>
+      </div>
+      <div class="record2">
+        <h4>第二回戦 vs 一橋大学</h4>
+        <p>1.髙橋(一) 瀧谷 3-⑤ 奥山 岡本</p>
+        <p>2.小八木 高橋(慧) 3-⑤ 板垣 服部</p>
+        <p>3.田淵 ④-3 大谷</p>
+        <p>4.田村 久保田 0-⑤ 西宮 石川</p>
+        <p>5.難波 三田 ⑤-0 島元 下鍋</p>
+        <p>以上2-③負け</p>
+      </div>
+      <div class="record2">
+        <h4>第三回戦 vs 獨協大学</h4>
+        <p>1.難波 三田 3-⑤ 亀川 大野</p>
+        <p>2.山本 久保田 ⑤-2 田中 明田</p>
+        <p>3.田淵 ④-2 小林</p>
+        <p>4.小八木 高橋(慧) 1-⑤ 阿部 鳥飼</p>
+        <p>5.髙橋(一) 瀧谷 ⑤-2 成塚 秋元</p>
+        <p>以上2-③負け</p>
+      </div>
+      <div class="record2">
+        <h4>第四回戦 vs東京都市大学</h4>
+        <p>1.難波 柴田 3-⑤ 鵜飼 志村</p>
+        <p>2.田村 久保田 ⑤-2 藤沼 小椋</p>
+        <p>3.田淵 ④-1 穴沢</p>
+        <p>4.小八木 高橋(慧) ⑤-4 杉浦 藤本</p>
+        <p>5.髙橋(一) 3-⑤ 堀越 杉原</p>
+        <p>以上③-2勝ち</p>
+      </div>
+      <div class="record2">
+        <h4>第五回戦 vs宇都宮大学</h4>
+        <p>1.難波 林 3-⑤ 大濱 髙橋</p>
+        <p>2.田村 久保田 0-⑤ 荻野 深井</p>
+        <p>3.田淵 ④-1 関島</p>
+        <p>4.髙橋(一) 瀧谷 ⑤-4 伊澤 永倉</p>
+        <p>5.小八木 高橋(慧) ⑤-0 岩田 川上</p>
+        <p>以上③-2勝ち</p>
+      </div>
+    </div>
+    <div class="foot">
+      <a class="back" href="../../../result.html">
+        <p>戦績一覧に戻る</p>
+      </a>
+    </div>
+    <footer>
+      <p id="copyright"><small>Copyright&copy; 2017 東京工業大学ソフトテニス部</small></p>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
2019年の関東学生ソフトテニス春季リーグ戦の結果を追加しました．